### PR TITLE
Note about IE8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ let prefix = (function () {
   if (typeof window === "undefined") {
     return {};
   }
-  var styles = window.getComputedStyle(document.documentElement, ''),
+  var styles = window.getComputedStyle(document.documentElement, ''), // This line is not supported in IE8
     pre = (Array.prototype.slice
       .call(styles)
       .join('')


### PR DESCRIPTION
This isn't really a PR. But I'm unable to open an issue, so here goes.

Could you do this in a way supported also in good old IE8? It's actually not polyfilled by either core-js or es5-shim...

Looking at the closest I could find (`document.documentElement.currentStyle`), it doesn't output prefixes. Fallback to `-ms-`?
